### PR TITLE
✨ feat(bot): add a spoiler flag and support masked links in messages

### DIFF
--- a/.changeset/fuzzy-bikes-work.md
+++ b/.changeset/fuzzy-bikes-work.md
@@ -1,0 +1,12 @@
+---
+"@embedly/builder": minor
+"@embedly/parser": minor
+"@embedly/bot": minor
+"@embedly/api": minor
+"@embedly/config": minor
+"@embedly/logging": minor
+"@embedly/platforms": minor
+"@embedly/types": minor
+---
+
+add a spoiler flag and support masked links in messages

--- a/apps/bot/src/listeners/messageCreate.ts
+++ b/apps/bot/src/listeners/messageCreate.ts
@@ -1,10 +1,11 @@
 import { treaty } from "@elysiajs/eden";
 import type { App } from "@embedly/api";
-import { Embed } from "@embedly/builder";
+import { Embed, EmbedFlags } from "@embedly/builder";
 import {
   GENERIC_LINK_REGEX,
   getPlatformFromURL,
-  hasLink
+  hasLink,
+  isSpoiler
 } from "@embedly/parser";
 import Platforms from "@embedly/platforms";
 import { Events, Listener } from "@sapphire/framework";
@@ -55,7 +56,11 @@ export class MessageListener extends Listener<
 
       const embed = Platforms[platform.type].createEmbed(data);
       const msg = {
-        components: [Embed.getDiscordEmbed(embed)],
+        components: [
+          Embed.getDiscordEmbed(embed, {
+            [EmbedFlags.Spoiler]: isSpoiler(url, message.content)
+          })
+        ],
         flags: MessageFlags.IsComponentsV2,
         allowedMentions: {
           parse: [],

--- a/packages/parser/src/parse.ts
+++ b/packages/parser/src/parse.ts
@@ -3,6 +3,7 @@ import {
   CBC_REGEX,
   GENERIC_LINK_REGEX,
   IG_REGEX,
+  SPOILER_LINK_REGEX,
   THREADS_REGEX,
   TIKTOK_REGEX_MAIN,
   TWITTER_REGEX
@@ -10,6 +11,10 @@ import {
 
 export function hasLink(content: string) {
   return GENERIC_LINK_REGEX.test(content);
+}
+
+export function isSpoiler(url: string, content: string) {
+  return SPOILER_LINK_REGEX(url).test(content);
 }
 
 export function getPlatformFromURL(

--- a/packages/parser/src/regex.ts
+++ b/packages/parser/src/regex.ts
@@ -1,5 +1,7 @@
 export const GENERIC_LINK_REGEX =
   /\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()[\]{};:'".,<>?«»“”‘’]))/i;
+export const SPOILER_LINK_REGEX = (url: string) =>
+  RegExp(`||\\s?${url}\\s?||`);
 export const TWITTER_REGEX =
   /(?:twitter|x).com\/.*\/status(?:es)?\/(?<tweet_id>[^/?]+)/;
 export const IG_REGEX =


### PR DESCRIPTION
### reworked the flags system and added `SPOILER` flag.

flags are now defined as an enum:
https://github.com/embed-team/embedly/blob/770c00a2fa3f4411c4fdd86c8bbf1657fbb357e7/packages/builder/src/Embed.ts#L33-L36

the new flag (`SPOILER`) supports:
- Discord's masked text syntax `||{text}||`
- being used as a command flag `/embed {url} spoiler:True`

---
<img width="908" height="420" alt="00VDm8WG@2x" src="https://github.com/user-attachments/assets/ad63861f-7e70-4fed-a00b-687051f936e5" />
<img width="982" height="520" alt="i1fl7KUb@2x" src="https://github.com/user-attachments/assets/73368351-af95-4df2-bc36-1f46f1e45980" />
