### PR TITLE
🐛 fix(platforms): twitter replies bubbling to top of thread

### DIFF
--- a/.changeset/evil-lamps-fold.md
+++ b/.changeset/evil-lamps-fold.md
@@ -1,0 +1,6 @@
+---
+"@embedly/platforms": patch
+"@embedly/bot": patch
+---
+
+fixed twitter replies bubbling to top of thread

--- a/apps/bot/src/commands/embed.ts
+++ b/apps/bot/src/commands/embed.ts
@@ -111,7 +111,7 @@ export class EmbedCommand extends Command {
     }
 
     try {
-      const embed = Platforms[platform.type].createEmbed(data);
+      const embed = await Platforms[platform.type].createEmbed(data);
       return await interaction.editReply({
         components: [Embed.getDiscordEmbed(embed, flags)],
         flags: ["IsComponentsV2"],

--- a/apps/bot/src/listeners/messageCreate.ts
+++ b/apps/bot/src/listeners/messageCreate.ts
@@ -54,7 +54,7 @@ export class MessageListener extends Listener<
       );
       if (error) return;
 
-      const embed = Platforms[platform.type].createEmbed(data);
+      const embed = await Platforms[platform.type].createEmbed(data);
       const msg = {
         components: [
           Embed.getDiscordEmbed(embed, {

--- a/packages/platforms/src/Platform.ts
+++ b/packages/platforms/src/Platform.ts
@@ -45,5 +45,5 @@ export abstract class EmbedlyPlatform {
   }
   abstract fetchPost<T>(post_id: string, env?: any): Promise<T>;
   abstract transformRawData(raw_data: any): BaseEmbedData;
-  abstract createEmbed<T>(post_data: T): Embed;
+  abstract createEmbed<T>(post_data: T): Promise<Embed> | Embed;
 }

--- a/packages/platforms/src/Twitter.ts
+++ b/packages/platforms/src/Twitter.ts
@@ -43,12 +43,7 @@ export class Twitter extends EmbedlyPlatform {
       throw { code, message };
     }
 
-    let tweet_data = tweet;
-    if (tweet.replying_to_status) {
-      tweet_data = await this.fetchPost(tweet.replying_to_status);
-      tweet_data.reply = tweet;
-    }
-    return tweet_data;
+    return tweet;
   }
 
   enrichTweetText(text_data: Record<string, any>) {
@@ -89,7 +84,7 @@ export class Twitter extends EmbedlyPlatform {
     };
   }
 
-  createEmbed(tweet_data: any): Embed {
+  async createEmbed(tweet_data: any): Promise<Embed> {
     const embed = new Embed(this.transformRawData(tweet_data));
     if (tweet_data.text !== "") {
       embed.setDescription(this.enrichTweetText(tweet_data.raw_text));
@@ -104,8 +99,10 @@ export class Twitter extends EmbedlyPlatform {
         }))
       );
     }
-    if (tweet_data.reply) {
-      const reply_tweet = tweet_data.reply;
+    if (tweet_data.replying_to_status) {
+      const reply_tweet = await this.fetchPost(
+        tweet_data.replying_to_status
+      );
       const reply_embed = new Embed(this.transformRawData(reply_tweet));
       if (reply_tweet.text !== "") {
         reply_embed.setDescription(


### PR DESCRIPTION
twitter replies would recursively bubble up to the top and thus lose in-between messages.