### PR TITLE
Fix Twitter URL facet replacement

### DIFF
--- a/packages/platforms/src/platforms/twitter.ts
+++ b/packages/platforms/src/platforms/twitter.ts
@@ -13,7 +13,11 @@ function enrichText(raw?: RawText) {
   let text = raw.text;
   for (const facet of raw.facets) {
     if (facet.type === "url") {
-      text = text.replace(facet.original!, facet.replacement!);
+      const source =
+        facet.original && text.includes(facet.original) ? facet.original : facet.display;
+      if (source && facet.replacement) {
+        text = text.replace(source, facet.replacement);
+      }
     }
     if (facet.type === "hashtag") {
       text = text.replace(
@@ -29,9 +33,6 @@ function enrichText(raw?: RawText) {
         new RegExp(`@${facet.original}`, "i"),
         `[@${facet.original}](https://x.com/${facet.original})`,
       );
-    }
-    if (facet.type === "url") {
-      text = text.replace(facet.display!, facet.replacement!);
     }
   }
   return he.decode(text);


### PR DESCRIPTION
## Summary\n- Replace Twitter URL facets exactly once, preferring the original URL text when present\n- Prevent expanded URL replacements from being processed again via display text and producing duplicated prefixes/slashes\n\n## Validation\n- Targeted Twitter transform reproduction for the Notion Status URL\n- pnpm exec tsc -p packages/platforms/tsconfig.json --noEmit\n- oxlint packages/platforms/src/platforms/twitter.ts\n- pnpm --filter @embedly/platforms exec oxfmt --check src/platforms/twitter.ts

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/eda4410f-7b4e-4726-a89d-f3e0c8922eea/pull/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->