### PR TITLE
fix(platforms): avoid duplicated Bluesky quote media

### DIFF
--- a/packages/platforms/src/platforms/bluesky.ts
+++ b/packages/platforms/src/platforms/bluesky.ts
@@ -54,10 +54,6 @@ async function parseMedia(post: BlueskyPost, record: AppBskyFeedPost.Record) {
   for (let ind = 0; ind < embeds.length; ind++) {
     const embed = embeds[ind];
 
-    if (AppBskyEmbedRecord.isView(embed) && AppBskyEmbedRecord.isViewRecord(embed.record)) {
-      embeds.push(...(embed.record.embeds ?? []));
-    }
-
     if (AppBskyEmbedImages.isView(embed)) {
       media.push(
         ...embed.images.map((image) => ({


### PR DESCRIPTION
## Summary

- stop Bluesky media parsing from pulling media out of quoted records
- keep record-with-media handling for media that belongs to the parent post

Fixes #83

## Checks

- pnpm --filter @embedly/bot build
- moon run :lint :fmt/check