### PR TITLE
fix tiktok video urls

### DIFF
--- a/packages/platforms/src/platforms/tiktok.ts
+++ b/packages/platforms/src/platforms/tiktok.ts
@@ -9,12 +9,19 @@ const FOLLOWUP_RE =
 
 async function parseMedia(raw: Record<string, any>): Promise<NormalizedPost["media"]> {
   if (raw.video) {
-    const videoURL = raw.video.PlayAddrStruct.UrlList[2];
-    const video = await fetch(videoURL, {
-      method: "GET",
-      redirect: "follow",
-    });
-    return [{ url: video.url, type: "video" }];
+    const urls = raw.video.PlayAddrStruct?.UrlList ?? [];
+    for (const url of urls) {
+      const video = await fetch(url, {
+        method: "GET",
+        redirect: "follow",
+        headers: {
+          Range: "bytes=0-0",
+        },
+      });
+      await video.body?.cancel();
+      if (!video.ok || !video.headers.get("Content-Type")?.startsWith("video/")) continue;
+      return [{ url, type: "video" }];
+    }
   }
   return [];
 }


### PR DESCRIPTION
## Summary

- verify TikTok video URL candidates with a range request
- return the original playable TikTok video URL instead of the final redirected CDN URL
- keep broken direct CDN candidates out of Discord embeds

## Root cause

The reported post exposes direct CDN URLs that return 403 here, plus an aweme/v1/play URL that returns 206 video/mp4. The old code chose the aweme URL, followed it server-side, and returned the redirected tiktokcdn URL. That final URL is fragile for Discord; the aweme URL itself is the usable URL Discord can follow.

## Validation

- pnpm exec moon ci platforms:lint platforms:fmt/check
- tested https://tiktok.com/@hijh7873/video/7636361168755395870
- confirmed direct CDN candidates return 403 and the selected aweme/v1/play candidate returns 206 video/mp4