### PR TITLE
fix tiktok media proxy urls

### DIFF
--- a/packages/platforms/src/platforms/tiktok.ts
+++ b/packages/platforms/src/platforms/tiktok.ts
@@ -10,18 +10,8 @@ const FOLLOWUP_RE =
 async function parseMedia(raw: Record<string, any>): Promise<NormalizedPost["media"]> {
   if (raw.video) {
     const urls = raw.video.PlayAddrStruct?.UrlList ?? [];
-    for (const url of urls) {
-      const video = await fetch(url, {
-        method: "GET",
-        redirect: "follow",
-        headers: {
-          Range: "bytes=0-0",
-        },
-      });
-      await video.body?.cancel();
-      if (!video.ok || !video.headers.get("Content-Type")?.startsWith("video/")) continue;
-      return [{ url, type: "video" }];
-    }
+    const videoURL = urls.find((url: string) => url.includes("/aweme/v1/play/")) ?? urls[0];
+    if (videoURL) return [{ url: videoURL, type: "video" }];
   }
   return [];
 }


### PR DESCRIPTION
## Summary

- stop probing TikTok video URLs from the API worker during media parsing
- pass TikTok's aweme/v1/play URL through the API response
- resolve that aweme URL in the bot builder with a range request and Discordbot UA before sending media to Discord

## Root cause

The hosted API worker can be blocked by TikTok when it tries to validate media URLs, leaving the transformed post with no media. The bot runtime is a better place to do the final media redirect check because it builds the Discord message immediately before sending it.

## Validation

- pnpm exec moon ci platforms:lint platforms:fmt/check
- pnpm exec moon ci bot:lint bot:fmt/check
- repro URL selects aweme/v1/play for https://tiktok.com/@hijh7873/video/7636361168755395870
- bot-side resolver follows that URL with Discordbot/2.0 and gets 206 video/mp4

Fixes #86