### PR TITLE
fix tiktok bot media urls

### DIFF
--- a/apps/bot/src/lib/builder.ts
+++ b/apps/bot/src/lib/builder.ts
@@ -34,6 +34,29 @@ export interface EmbedFlags {
 
 type PostData = Awaited<ReturnType<(typeof Platforms)[keyof typeof Platforms]["transform"]>>;
 
+async function resolveMedia(media: NormalizedPost["media"]) {
+  const resolved = [];
+  for (const item of media) {
+    if (item.type !== "video" || !item.url.includes("tiktok")) {
+      resolved.push(item);
+      continue;
+    }
+
+    const response = await fetch(item.url, {
+      method: "GET",
+      redirect: "follow",
+      headers: {
+        Range: "bytes=0-0",
+        "User-Agent": "Discordbot/2.0",
+      },
+    });
+    await response.body?.cancel();
+    if (!response.ok || !response.headers.get("Content-Type")?.startsWith("video/")) continue;
+    resolved.push({ ...item, url: response.url });
+  }
+  return resolved;
+}
+
 function buildMediaEmbed(media: NormalizedPost["media"], spoiler?: EmbedFlags["Spoiler"]) {
   if (media.length === 0) return null;
 
@@ -45,7 +68,7 @@ function buildMediaEmbed(media: NormalizedPost["media"], spoiler?: EmbedFlags["S
   return gallery.toJSON();
 }
 
-function addPostComponents(embed: ContainerBuilder, post: PostData, headingPrefix?: string) {
+async function addPostComponents(embed: ContainerBuilder, post: PostData, headingPrefix?: string) {
   const translation =
     post.platform === "Twitter" &&
     post.translation &&
@@ -93,8 +116,9 @@ function addPostComponents(embed: ContainerBuilder, post: PostData, headingPrefi
       );
     }
   }
-  if (post.media.length > 0) {
-    embed.addMediaGalleryComponents(buildMediaEmbed(post.media)!);
+  const media = await resolveMedia(post.media);
+  if (media.length > 0) {
+    embed.addMediaGalleryComponents(buildMediaEmbed(media)!);
   }
   embed
     .addSeparatorComponents((sep) => sep.setDivider(false).setSpacing(SeparatorSpacingSize.Small))
@@ -114,9 +138,9 @@ function addPostComponents(embed: ContainerBuilder, post: PostData, headingPrefi
     );
 }
 
-export function buildEmbed(post: PostData, flags?: Partial<EmbedFlags>) {
+export async function buildEmbed(post: PostData, flags?: Partial<EmbedFlags>) {
   if (flags?.MediaOnly) {
-    return buildMediaEmbed(post.media, flags?.Spoiler);
+    return buildMediaEmbed(await resolveMedia(post.media), flags?.Spoiler);
   }
 
   const embed = new ContainerBuilder();
@@ -126,18 +150,18 @@ export function buildEmbed(post: PostData, flags?: Partial<EmbedFlags>) {
   }
 
   if (flags?.SourceOnly) {
-    addPostComponents(embed, post);
+    await addPostComponents(embed, post);
     return embed.toJSON();
   }
 
   if (post.reply_to) {
-    addPostComponents(embed, post.reply_to);
+    await addPostComponents(embed, post.reply_to);
     embed.addSeparatorComponents((sep) =>
       sep.setDivider(true).setSpacing(SeparatorSpacingSize.Large),
     );
   }
 
-  addPostComponents(
+  await addPostComponents(
     embed,
     post,
     post.reply_to ? getEmojiByName("reply") : post.quote ? getEmojiByName("quote") : undefined,
@@ -147,7 +171,7 @@ export function buildEmbed(post: PostData, flags?: Partial<EmbedFlags>) {
     embed.addSeparatorComponents((sep) =>
       sep.setDivider(true).setSpacing(SeparatorSpacingSize.Large),
     );
-    addPostComponents(embed, post.quote);
+    await addPostComponents(embed, post.quote);
   }
 
   return embed.toJSON();

--- a/packages/platforms/src/platforms/tiktok.ts
+++ b/packages/platforms/src/platforms/tiktok.ts
@@ -9,9 +9,12 @@ const FOLLOWUP_RE =
 
 async function parseMedia(raw: Record<string, any>): Promise<NormalizedPost["media"]> {
   if (raw.video) {
-    const urls = raw.video.PlayAddrStruct?.UrlList ?? [];
-    const videoURL = urls.find((url: string) => url.includes("/aweme/v1/play/")) ?? urls[0];
-    if (videoURL) return [{ url: videoURL, type: "video" }];
+    const urls = [
+      raw.video.playAddr,
+      raw.video.downloadAddr,
+      ...(raw.video.PlayAddrStruct?.UrlList ?? []),
+    ].filter((url) => typeof url === "string" && url.length > 0);
+    return [...new Set(urls)].map((url) => ({ url, type: "video" }));
   }
   return [];
 }


### PR DESCRIPTION
## Summary

- return all TikTok video URL candidates from the platform transform without worker-side probing
- resolve TikTok video candidates in the bot builder with a one-byte range request and Discordbot UA
- send Discord the final redirected video URL only when TikTok returns video content

## Root cause

The API worker can be blocked by TikTok when checking media URLs, but the bot can resolve the playable TikTok URL immediately before sending the Discord message. Returning all candidates keeps the API response complete while letting the bot choose the URL Discord can actually use.

## Validation

- pnpm exec moon ci bot:lint bot:fmt/check platforms:lint platforms:fmt/check
- repro URL returned four TikTok candidates
- bot-side check dropped the 403 candidates and kept the aweme/v1/play candidate returning 206 video/mp4

Fixes #86