### PR TITLE
fix: harden embed failure handling

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -76,16 +76,13 @@ const app = new Hono<{ Bindings: CloudflareBindings }>()
               return c.json(cachedItem as ScrapeResponse, 200);
             }
           } catch (cause) {
-            const problem = createProblem(EmbedlyErrors.CacheReadFailed, {
-              request_id: requestId,
-              context: { ...logContext, ...getErrorContext(cause) },
-            });
-            Object.assign(logContext, getErrorContext(cause), {
-              outcome: "error",
-              status_code: problem.status,
-              error_type: problem.type,
-            });
-            return c.json(problem, problem.status);
+            logContext.cache_status = "read_error";
+            console.warn(
+              formatLog("warn", EmbedlyErrors.CacheReadFailed, {
+                ...logContext,
+                ...getErrorContext(cause),
+              }),
+            );
           }
         }
 
@@ -145,16 +142,13 @@ const app = new Hono<{ Bindings: CloudflareBindings }>()
           });
           logContext.cache_status = "stored";
         } catch (cause) {
-          const problem = createProblem(EmbedlyErrors.CacheWriteFailed, {
-            request_id: requestId,
-            context: { ...logContext, ...getErrorContext(cause) },
-          });
-          Object.assign(logContext, getErrorContext(cause), {
-            outcome: "error",
-            status_code: problem.status,
-            error_type: problem.type,
-          });
-          return c.json(problem, problem.status);
+          logContext.cache_status = "write_error";
+          console.warn(
+            formatLog("warn", EmbedlyErrors.CacheWriteFailed, {
+              ...logContext,
+              ...getErrorContext(cause),
+            }),
+          );
         }
 
         return c.json(data, 200);

--- a/apps/bot/compose.yaml
+++ b/apps/bot/compose.yaml
@@ -11,7 +11,7 @@ services:
       timeout: 1s
       retries: 30
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
 
   bot:
     container_name: embedly-bot

--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "@embedly/config": "workspace:*",
     "@types/node": "catalog:",
-    "dotenv": "^17.4.2",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "tsdown": "^0.22.0",

--- a/apps/bot/src/commands/delete.ts
+++ b/apps/bot/src/commands/delete.ts
@@ -196,7 +196,6 @@ export class DeleteCommand extends Command {
 
           try {
             await msg.delete();
-            await this.container.messageCache.removeBotMessage(msg.id);
           } catch (error) {
             const problem = createProblem(EmbedlyErrors.DeleteFailed, {
               request_id: requestId,
@@ -214,6 +213,20 @@ export class DeleteCommand extends Command {
             botErrors.add(1, { ...metricContext, error_type: problem.type });
             await interaction.editReply(formatDiscordError(problem));
             return;
+          }
+
+          try {
+            await this.container.messageCache.removeBotMessage(msg.id);
+          } catch (error) {
+            botErrors.add(1, {
+              ...metricContext,
+              error_type: EmbedlyErrors.MessageCacheFailed.type,
+            });
+            log("warn", EmbedlyErrors.MessageCacheFailed, {
+              ...logContext,
+              error_type: EmbedlyErrors.MessageCacheFailed.type,
+              ...getErrorContext(error),
+            });
           }
 
           await interaction.editReply(

--- a/apps/bot/src/lib/handleUrls.ts
+++ b/apps/bot/src/lib/handleUrls.ts
@@ -105,18 +105,51 @@ export async function handleUrls(
 
   if (interaction) await interaction.deferReply();
 
+  let matchFailures = 0;
+  const matchContext = msg
+    ? {
+        message_id: msg.id,
+        channel_id: msg.channelId,
+        guild_id: msg.guildId ?? "dm",
+        user_id: msg.author.id,
+      }
+    : {
+        interaction_id: interaction!.id,
+        channel_id: interaction!.channelId,
+        guild_id: interaction!.guildId ?? "dm",
+        user_id: interaction!.user.id,
+      };
   const matches = (
     await Promise.all(
-      urls.map(async (request) => {
-        const match = await matchURL(request.url);
-        return match ? { ...request, ...match } : null;
+      urls.map(async (request, index) => {
+        try {
+          const match = await matchURL(request.url);
+          return match ? { ...request, ...match } : null;
+        } catch (error) {
+          matchFailures++;
+          const requestId = msg
+            ? `message:${msg.id}:match:${index}`
+            : `${embedSource}:${interaction!.id}:match:${index}`;
+          container.logger.warn(
+            formatLog("warn", EmbedlyErrors.ApiUnexpectedResponse, {
+              request_id: requestId,
+              source: embedSource,
+              ...matchContext,
+              ...getErrorContext(error),
+            }),
+          );
+          if (msg) await reactToFailure();
+          return null;
+        }
       }),
     )
   ).filter((m) => m !== null);
 
   if (interaction && matches.length === 0) {
     const requestId = `${embedSource}:${interaction.id}`;
-    const problem = createProblem(EmbedlyErrors.NoMatchesFound, {
+    const error =
+      matchFailures > 0 ? EmbedlyErrors.ApiUnexpectedResponse : EmbedlyErrors.NoMatchesFound;
+    const problem = createProblem(error, {
       request_id: requestId,
       context: {
         request_id: requestId,
@@ -125,7 +158,7 @@ export async function handleUrls(
         user_id: interaction.user.id,
       },
     });
-    container.logger.warn(formatLog("warn", EmbedlyErrors.NoMatchesFound, problem.context));
+    container.logger.warn(formatLog("warn", error, problem.context));
     await interaction.editReply({
       content: formatDiscordError(problem),
     });

--- a/apps/bot/src/lib/handleUrls.ts
+++ b/apps/bot/src/lib/handleUrls.ts
@@ -328,8 +328,9 @@ export async function handleUrls(
             },
           } as const;
 
+          let botMessage: Message;
           try {
-            const botMessage = await span(
+            botMessage = await span(
               "discord.send",
               {
                 ...spanAttributes,
@@ -348,22 +349,6 @@ export async function handleUrls(
                 return message;
               },
             );
-            logContext.bot_message_id = botMessage.id;
-            if (msg) {
-              await span(
-                "message_cache.save",
-                {
-                  ...spanAttributes,
-                  "discord.source_message_id": msg.id,
-                  "discord.bot_message_id": botMessage.id,
-                },
-                async () => {
-                  await container.messageCache.save(msg.id, botMessage.id, msg.author.id);
-                },
-              );
-            }
-            botEmbedsCreated.add(1, metricContext);
-            sentEmbed = true;
           } catch (error) {
             recordError(requestSpan, error);
             const problem = createProblem(EmbedlyErrors.DiscordSendFailed, {
@@ -381,6 +366,37 @@ export async function handleUrls(
               return;
             }
             await interaction!.editReply(formatDiscordError(problem));
+            return;
+          }
+
+          logContext.bot_message_id = botMessage.id;
+          botEmbedsCreated.add(1, metricContext);
+          sentEmbed = true;
+
+          if (msg) {
+            try {
+              await span(
+                "message_cache.save",
+                {
+                  ...spanAttributes,
+                  "discord.source_message_id": msg.id,
+                  "discord.bot_message_id": botMessage.id,
+                },
+                async () => {
+                  await container.messageCache.save(msg.id, botMessage.id, msg.author.id);
+                },
+              );
+            } catch (error) {
+              botErrors.add(1, {
+                ...metricContext,
+                error_type: EmbedlyErrors.MessageCacheFailed.type,
+              });
+              log("warn", EmbedlyErrors.MessageCacheFailed, {
+                ...logContext,
+                error_type: EmbedlyErrors.MessageCacheFailed.type,
+                ...getErrorContext(error),
+              });
+            }
           }
         } finally {
           Object.assign(logContext, getActiveTraceContext(), {

--- a/apps/bot/src/lib/messageCache.ts
+++ b/apps/bot/src/lib/messageCache.ts
@@ -83,18 +83,6 @@ export class MessageCache {
     return sourceMessage?.botMessageIds ?? [];
   }
 
-  public async deleteSourceMessage(sourceMessageId: string) {
-    const botMessageIds = await this.getBotMessageIds(sourceMessageId);
-    const keys = [
-      this.getSourceMessageKey(sourceMessageId),
-      ...botMessageIds.map((id) => this.getBotMessageAuthorKey(id)),
-      ...botMessageIds.map((id) => this.getBotMessageSourceKey(id)),
-    ];
-
-    await this.client.del(keys);
-    return botMessageIds;
-  }
-
   public async close() {
     await this.client.close();
   }

--- a/apps/bot/src/lib/utils.ts
+++ b/apps/bot/src/lib/utils.ts
@@ -18,14 +18,6 @@ export function extractURLs(content: string): URLMatch[] {
   });
 }
 
-export function isSpoiler(url: string, content: string): boolean {
-  return content.split("||").some((part, ind) => ind % 2 === 1 && part.includes(url));
-}
-
-export function isEscaped(url: string, content: string): boolean {
-  return content.includes(`<${url}>`);
-}
-
 export function truncate(text: string, maxLength: number) {
   return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
 }

--- a/apps/bot/src/listeners/messageCreate.ts
+++ b/apps/bot/src/listeners/messageCreate.ts
@@ -3,7 +3,7 @@ import { MessageFlags, type Message } from "discord.js";
 
 import type { EmbedFlags } from "../lib/builder";
 import { handleUrls, type EmbedURLRequest } from "../lib/handleUrls";
-import { extractURLs, isSpoiler } from "../lib/utils";
+import { extractURLs } from "../lib/utils";
 
 function parseMessageURLs(content: string) {
   const urls: EmbedURLRequest[] = [];
@@ -21,7 +21,7 @@ function parseMessageURLs(content: string) {
     }
 
     const flags: Partial<EmbedFlags> = {
-      Spoiler: isSpoiler(match.url, content),
+      Spoiler: content.slice(0, match.index).split("||").length % 2 === 0,
     };
     let force = false;
 

--- a/apps/bot/src/listeners/messageDelete.ts
+++ b/apps/bot/src/listeners/messageDelete.ts
@@ -30,7 +30,6 @@ export class MessageDeleteListener extends Listener<typeof Events.MessageDelete>
             ...getErrorContext(error),
           }),
         );
-        continue;
       }
 
       try {

--- a/apps/bot/src/listeners/messageDelete.ts
+++ b/apps/bot/src/listeners/messageDelete.ts
@@ -11,17 +11,34 @@ export class MessageDeleteListener extends Listener<typeof Events.MessageDelete>
   }
 
   public async run(message: Message | PartialMessage) {
-    const botMessageIds = await this.container.messageCache.deleteSourceMessage(message.id);
+    const requestId = `message:${message.id}`;
+    const botMessageIds = await this.container.messageCache.getBotMessageIds(message.id);
     if (botMessageIds.length === 0) return;
 
+    let deletedCount = 0;
     for (const botMessageId of botMessageIds) {
       try {
         const botMessage = await message.channel.messages.fetch(botMessageId);
         await botMessage.delete();
+        deletedCount++;
       } catch (error) {
         this.container.logger.warn(
           formatLog("warn", EmbedlyErrors.DeleteFailed, {
-            request_id: `message:${message.id}`,
+            request_id: requestId,
+            message_id: message.id,
+            bot_message_id: botMessageId,
+            ...getErrorContext(error),
+          }),
+        );
+        continue;
+      }
+
+      try {
+        await this.container.messageCache.removeBotMessage(botMessageId);
+      } catch (error) {
+        this.container.logger.warn(
+          formatLog("warn", EmbedlyErrors.MessageCacheFailed, {
+            request_id: requestId,
             message_id: message.id,
             bot_message_id: botMessageId,
             ...getErrorContext(error),
@@ -30,12 +47,19 @@ export class MessageDeleteListener extends Listener<typeof Events.MessageDelete>
       }
     }
 
-    this.container.logger.info(
-      formatLog("info", EmbedlyLogs.AutoDeleteSucceeded, {
-        request_id: `message:${message.id}`,
-        message_id: message.id,
-        bot_message_count: botMessageIds.length,
-      }),
-    );
+    const failedCount = botMessageIds.length - deletedCount;
+    const context = {
+      request_id: requestId,
+      message_id: message.id,
+      bot_message_count: botMessageIds.length,
+      deleted_count: deletedCount,
+      failed_count: failedCount,
+    };
+    if (failedCount > 0) {
+      this.container.logger.warn(formatLog("warn", EmbedlyErrors.DeleteFailed, context));
+      return;
+    }
+
+    this.container.logger.info(formatLog("info", EmbedlyLogs.AutoDeleteSucceeded, context));
   }
 }

--- a/packages/platforms/src/platforms/threads.ts
+++ b/packages/platforms/src/platforms/threads.ts
@@ -9,11 +9,7 @@ const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789
 
 function parseMedia(raw: Record<string, any>): NormalizedPost["media"] {
   if (raw.carousel_media) {
-    return raw.carousel_media.map((media: any) => ({
-      url: media.image_versions2.candidates[0].url,
-      type: "photo",
-      description: media.accessibility_caption,
-    }));
+    return raw.carousel_media.flatMap(parseMedia);
   }
   if (raw.video_versions) {
     return [

--- a/packages/platforms/src/platforms/twitter.ts
+++ b/packages/platforms/src/platforms/twitter.ts
@@ -1,7 +1,7 @@
 import he from "he";
 
 import { version } from "../../package.json";
-import { Platform } from "../types";
+import { NormalizedPost, Platform } from "../types";
 import type { APITwitterStatus, FxTweetResponse, RawText } from "./twitter.d";
 
 const MATCH_RE =
@@ -190,6 +190,11 @@ export const Twitter: Platform<"Twitter", APITwitterStatus, TwitterMeta> = {
           type: m.type,
           description: "altText" in m && typeof m.altText === "string" ? m.altText : undefined,
         })) ?? []);
+    let replyTo: NormalizedPost | undefined;
+    if (includeContext && raw.replying_to) {
+      const parent = await this.fetch(raw.replying_to.status).catch(() => undefined);
+      if (parent) replyTo = await this.transform(parent, { depth: depth + 1 });
+    }
 
     return {
       platform: this.type,
@@ -214,10 +219,7 @@ export const Twitter: Platform<"Twitter", APITwitterStatus, TwitterMeta> = {
         includeContext && raw.quote?.type === "status"
           ? await this.transform(raw.quote, { depth: depth + 1 })
           : undefined,
-      reply_to:
-        includeContext && raw.replying_to
-          ? await this.transform(await this.fetch(raw.replying_to.status), { depth: depth + 1 })
-          : undefined,
+      reply_to: replyTo,
 
       article: raw.article,
       community_note: enrichText(raw.community_note),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,9 +154,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.0
-      dotenv:
-        specifier: ^17.4.2
-        version: 17.4.2
       oxfmt:
         specifier: 'catalog:'
         version: 0.47.0
@@ -8124,7 +8121,8 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
-  dotenv@17.4.2: {}
+  dotenv@17.4.2:
+    optional: true
 
   dotenv@8.6.0: {}
 


### PR DESCRIPTION
fixes failure paths around url matching, redis, kv, and deleting embeds. one bad short link won't stall the rest, and an embed that already sent won't get reported as failed because redis had a problem.

threads carousel videos use video media instead of thumbnails, missing twitter parents no longer kill the main embed, and duplicate urls keep separate spoiler state. dev cache stays available on localhost. also drops the unused bot dotenv dep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - API requests continue when cache operations fail, with warnings recorded instead of errors.
  - Message deletion and URL processing remain successful when cache cleanup or persistence encounters problems.
  - Failed message deletions now provide clearer status reporting.
  - Improved handling of nested carousel media and Twitter reply context.

- **Security**
  - The cache service is now accessible only from the local machine.

- **Maintenance**
  - Removed unused configuration and helper functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->